### PR TITLE
Add session management menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,12 +25,24 @@
 		<button id="join-btn">Join</button>
 	</section>
 
-	<!-- ========== ACTION BUTTONS ========== -->
-	<section id="action-section" class="hidden">
-		<h2>Order Sets</h2>
-		<button id="add-set-3">➕ Add 3‑Pint Set</button>
-		<button id="add-set-5">➕ Add 5‑Glass Set</button>
-	</section>
+        <!-- ========== ACTION BUTTONS ========== -->
+        <section id="action-section" class="hidden">
+                <h2>Order Sets</h2>
+                <button id="add-set-3">➕ Add 3‑Pint Set</button>
+                <button id="add-set-5">➕ Add 5‑Glass Set</button>
+                <button id="toggle-manage">⚙ Manage</button>
+        </section>
+
+        <!-- ========== MANAGE MENU ========== -->
+        <section id="manage-section" class="hidden">
+                <h2>Manage Session</h2>
+                <button id="remove-last-set" class="danger">Remove Last Set</button>
+                <div>
+                        <select id="manage-user-select"></select>
+                </div>
+                <button id="subtract-drink" class="danger">Subtract Drink</button>
+                <button id="remove-user" class="danger">Remove User</button>
+        </section>
 
 	<!-- ========== USER DRINK BUTTONS ========== -->
 	<section id="users-section" class="hidden">

--- a/script.js
+++ b/script.js
@@ -49,6 +49,13 @@ const joinBtn      = document.querySelector('#join-btn');
 const actionSection = document.querySelector('#action-section');
 const add3Btn      = document.querySelector('#add-set-3');
 const add5Btn      = document.querySelector('#add-set-5');
+const toggleManageBtn = document.querySelector('#toggle-manage');
+
+const manageSection = document.querySelector('#manage-section');
+const removeLastSetBtn = document.querySelector('#remove-last-set');
+const userSelect = document.querySelector('#manage-user-select');
+const subtractDrinkBtn = document.querySelector('#subtract-drink');
+const removeUserBtn = document.querySelector('#remove-user');
 
 const usersSection = document.querySelector('#users-section');
 const usersContainer = document.querySelector('#users-container');
@@ -113,6 +120,41 @@ joinBtn.addEventListener('click', () => {
 // 2) Add Set Buttons
 add3Btn.addEventListener('click', () => handleAddSet(3));
 add5Btn.addEventListener('click', () => handleAddSet(5));
+toggleManageBtn.addEventListener('click', () => {
+        manageSection.classList.toggle('hidden');
+        updateManageSelect();
+});
+
+removeLastSetBtn.addEventListener('click', () => {
+        if (session.sets.length === 0) return;
+        const removed = session.sets.shift();
+        log(`Removed last set of ${removed.type}`);
+        saveSession();
+        updateUI();
+});
+
+subtractDrinkBtn.addEventListener('click', () => {
+        const name = userSelect.value;
+        if (!name) return;
+        if (session.users[name] > 0) {
+                session.users[name] -= 1;
+                log(`Corrected drink for ${name}`);
+                saveSession();
+                updateUI();
+        }
+});
+
+removeUserBtn.addEventListener('click', () => {
+        const name = userSelect.value;
+        if (!name) return;
+        if (confirm(`Remove user ${name}?`)) {
+                delete session.users[name];
+                log(`${name} was removed`);
+                saveSession();
+                updateUI();
+                updateManageSelect();
+        }
+});
 
 function handleAddSet(size) {
 	const now = Date.now();
@@ -136,10 +178,10 @@ resetBtn.addEventListener('click', () => {
 
 /* ------------------ Dynamic User Drink Buttons ------------------ */
 function createUserButtons() {
-	usersContainer.innerHTML = ''; // Clear
-	for (const [name, count] of Object.entries(session.users)) {
-		const btn = document.createElement('button');
-		btn.textContent = `${name} (${count})`;
+        usersContainer.innerHTML = ''; // Clear
+        for (const [name, count] of Object.entries(session.users)) {
+                const btn = document.createElement('button');
+                btn.textContent = `${name} (${count})`;
 		btn.addEventListener('click', () => {
 			session.users[name] += 1;
 			log(`${name} drank one!`);
@@ -147,8 +189,22 @@ function createUserButtons() {
 			updateUI();
 			triggerAnimation(btn);
 		});
-		usersContainer.appendChild(btn);
-	}
+                usersContainer.appendChild(btn);
+        }
+}
+
+function updateManageSelect() {
+        userSelect.innerHTML = '';
+        const opt = document.createElement('option');
+        opt.value = '';
+        opt.textContent = 'Select User';
+        userSelect.appendChild(opt);
+        Object.keys(session.users).forEach(name => {
+                const o = document.createElement('option');
+                o.value = name;
+                o.textContent = name;
+                userSelect.appendChild(o);
+        });
 }
 
 /* ------------------ Leaderboard & Stats ------------------ */
@@ -217,14 +273,16 @@ function updateUI() {
 	// Toggle hidden sections based on whether we have any users
 	const hasUsers = Object.keys(session.users).length > 0;
 
-	[ actionSection, usersSection, dashboardSection,
-	  achievementsSection, logSection, resetFooter
-	].forEach(el => el.classList.toggle('hidden', !hasUsers));
+        [ actionSection, usersSection, dashboardSection,
+          achievementsSection, logSection, resetFooter,
+          manageSection
+        ].forEach(el => el.classList.toggle('hidden', !hasUsers));
 
-	createUserButtons();
-	updateDashboard();
-	checkAchievements();
-	updateLog();
+        createUserButtons();
+        updateManageSelect();
+        updateDashboard();
+        checkAchievements();
+        updateLog();
 }
 
 /* ------------------ Tiny Animation Helper ------------------ */


### PR DESCRIPTION
## Summary
- add Manage menu with options to undo sets or drinks and remove users
- implement session correction logic in JavaScript

## Testing
- `node -e "require('./script.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6857bb114d2c8320b72749a1ae41ab90