### PR TITLE
Reposition manage actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,16 +33,6 @@
                 <button id="toggle-manage">⚙ Manage</button>
         </section>
 
-        <!-- ========== MANAGE MENU ========== -->
-        <section id="manage-section" class="hidden">
-                <h2>Manage Session</h2>
-                <button id="remove-last-set" class="danger">Remove Last Set</button>
-                <div>
-                        <select id="manage-user-select"></select>
-                </div>
-                <button id="subtract-drink" class="danger">Subtract Drink</button>
-                <button id="remove-user" class="danger">Remove User</button>
-        </section>
 
 	<!-- ========== USER DRINK BUTTONS ========== -->
 	<section id="users-section" class="hidden">
@@ -79,11 +69,22 @@
 		<ul id="achievements-list"><!-- Filled dynamically --></ul>
 	</section>
 
-	<!-- ========== SESSION LOG ========== -->
-	<section id="log-section" class="hidden">
-		<h2>Session Activity Log</h2>
-		<ul id="log-list"><!-- Filled dynamically --></ul>
-	</section>
+        <!-- ========== SESSION LOG ========== -->
+        <section id="log-section" class="hidden">
+                <h2>Session Activity Log</h2>
+                <ul id="log-list"><!-- Filled dynamically --></ul>
+        </section>
+
+        <!-- ========== MANAGE MENU ========== -->
+        <section id="manage-section" class="hidden">
+                <h2>Manage Session</h2>
+                <button id="remove-last-set" class="danger">Remove Last Set</button>
+                <div>
+                        <select id="manage-user-select"></select>
+                </div>
+                <button id="subtract-drink" class="danger">Subtract Drink</button>
+                <button id="remove-user" class="danger">Remove User</button>
+        </section>
 
 	<!-- ========== RESET BUTTON ========== -->
 	<footer class="hidden" id="reset-footer">


### PR DESCRIPTION
## Summary
- move manage menu to bottom of the page so rare actions are less prominent

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6857bce6eee08320bc063e4f5865697b