### PR TITLE
Improve manage button and subtract workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>WDWD – What Did We Drink?</title>
 
-	<!-- Link to the external stylesheet -->
-	<link rel="stylesheet" href="styles.css" />
+        <!-- External styles & fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
 	<header>
@@ -29,8 +32,7 @@
         <section id="action-section" class="hidden">
                 <h2>Order Sets</h2>
                 <button id="add-set-3">➕ Add 3‑Pint Set</button>
-                <button id="add-set-5">➕ Add 5‑Glass Set</button>
-                <button id="toggle-manage">⚙ Manage</button>
+               <button id="add-set-5">➕ Add 5‑Glass Set</button>
         </section>
 
 
@@ -75,16 +77,21 @@
                 <ul id="log-list"><!-- Filled dynamically --></ul>
         </section>
 
-        <!-- ========== MANAGE MENU ========== -->
-        <section id="manage-section" class="hidden">
-                <h2>Manage Session</h2>
-                <button id="remove-last-set" class="danger">Remove Last Set</button>
-                <div>
-                        <select id="manage-user-select"></select>
-                </div>
-                <button id="subtract-drink" class="danger">Subtract Drink</button>
-                <button id="remove-user" class="danger">Remove User</button>
-        </section>
+       <!-- ========== MANAGE MENU ========== -->
+       <section id="manage-section" class="hidden">
+               <h2>Management Tools</h2>
+               <p class="note manage-note">Select a user below to subtract a drink or remove them.</p>
+               <button id="remove-last-set" class="danger">Remove Last Set</button>
+               <div>
+                       <select id="manage-user-select"></select>
+               </div>
+               <button id="subtract-drink" class="danger" disabled>Subtract Drink</button>
+               <button id="remove-user" class="danger" disabled>Remove User</button>
+       </section>
+
+       <footer id="manage-footer" class="hidden">
+               <button id="toggle-manage" title="Open management tools">🛠️ Tools</button>
+       </footer>
 
 	<!-- ========== RESET BUTTON ========== -->
 	<footer class="hidden" id="reset-footer">

--- a/styles.css
+++ b/styles.css
@@ -17,13 +17,13 @@
 * { box-sizing: border-box; }
 
 body {
-	margin: 0;
-	font-family: system-ui, sans-serif;
-	background: #f7f7f7;
-	color: var(--secondary);
-	display: flex;
-	flex-direction: column;
-	min-height: 100vh;
+        margin: 0;
+        font-family: 'Inter', system-ui, sans-serif;
+        background: linear-gradient(135deg, #fdfbfb 0%, #ebedee 100%);
+        color: var(--secondary);
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
 }
 
 header, section, footer {
@@ -102,14 +102,57 @@ tr:nth-child(even) { background: #fafafa; }
 .pop { animation: pop 0.6s ease-out forwards; }
 
 @keyframes slide-in {
-	from { transform: translateY(30px); opacity: 0; }
-	to   { transform: translateY(0);   opacity: 1; }
+        from { transform: translateY(30px); opacity: 0; }
+        to   { transform: translateY(0);   opacity: 1; }
 }
 .slide-in { animation: slide-in 0.4s ease-out forwards; }
 
-/* Footer */
-footer {
-	margin-top: auto;
-	text-align: center;
+@keyframes fade-up {
+        from { opacity: 0; transform: translateY(20px); }
+        to   { opacity: 1; transform: translateY(0); }
 }
+.fade-up { animation: fade-up 0.4s ease-out forwards; }
+
+/* Footer */
+#reset-footer {
+       margin-top: auto;
+       text-align: center;
+}
+
+#manage-footer {
+       text-align: center;
+       margin-bottom: 1rem;
+}
+
 .note { font-size: 0.8rem; color: #555; }
+.manage-note { margin-top: 0; text-align: center; }
+
+button:disabled {
+        opacity: 0.6;
+        cursor: default;
+}
+
+/* Manage Panel */
+#manage-section {
+        border: 2px dashed var(--secondary);
+        background: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(4px);
+        border-radius: var(--radius);
+        margin-top: 1rem;
+        box-shadow: var(--shadow);
+        transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+select {
+        padding: 0.5rem;
+        border-radius: var(--radius);
+        border: 1px solid #ccc;
+        margin: 0.4rem 0;
+}
+
+#users-container {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+}
+#users-container button { margin: 0.25rem; }


### PR DESCRIPTION
## Summary
- clarify manage button label
- add instructions and disabled state in manage panel
- disable management actions until a user is chosen
- show button text as "Close Tools" when panel open
- style disabled buttons
- move the toggle down to a dedicated footer near the manage panel
- add fade-in animations and fix button highlight

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857c350c5d88320b720a82bbebf5ad2