### PR TITLE
Serve frontend and document centralized hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@
    node server.js
    ```
 
-3. Open `index.html` in your browser while the server is running.
+3. With the server running, open `http://localhost:3000/` (or your server's
+   address) in any browser. Every user visiting this URL shares the same
+   session.
 
 The current drinking session is shared across all users connecting to the same
-server. Sessions are automatically archived and cleared after 24 hours.
+server. Deploy the server on a reachable machine (for example a home server or
+cloud host) and ensure the port is accessible so everyone can use the same
+session. Sessions are automatically archived and cleared after 24 hours.

--- a/server.js
+++ b/server.js
@@ -1,7 +1,13 @@
 const fs = require('fs');
+const path = require('path');
 const express = require('express');
 const app = express();
 app.use(express.json());
+// Serve the frontend files so clients can load the app remotely
+app.use(express.static(__dirname));
+app.get('/', (req, res) => {
+    res.sendFile(path.join(__dirname, 'index.html'));
+});
 const PORT = process.env.PORT || 3000;
 
 const DAY_MS = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary
- serve index.html and assets from `server.js` so clients load from the same server
- clarify hosting instructions in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870d084f12c8320bab0ecd42a31345b